### PR TITLE
Add link to C++17 production implementation in VAST

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Production implementations
 - Elastic Common Schema: https://github.com/elastic/ecs/blob/master/schemas/network.yml
 - Moloch (1.7.0+): https://github.com/aol/moloch/issues/966
 - Suricata (4.1+): https://suricata.readthedocs.io/en/suricata-4.1.2/output/eve/eve-json-output.html#community-flow-id
+- VAST: https://github.com/vast-io/vast/pull/525
 - Zeek package (2.5+): https://github.com/corelight/bro-community-id
 
 Talks


### PR DESCRIPTION
This PR adds a link to a C++17 implementation in VAST, which covers the complete Community ID functionality as given by the spec.