### PR TITLE
Adding clarification on directionality of endpoints in netflow 5 tuple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Technical details
   components use network byte order (big-endian) to standardize
   ordering regardless of host hardware.
 
+- The hash input is ordered in a standardized way to abstract away
+  directionality. For example, the following netflow 5 tuples 
+  create identical Community ID hashes:
+  - Proto: TCP; SRC IP: 10.0.0.1; DST IP: 127.0.0.1; SRC Port: 1234; DST Port: 80
+  - Proto: TCP; SRC IP: 127.0.0.1; DST IP: 10.0.0.1; SRC Port: 80; DST Port: 1234
+
 - This version includes the following protocols and fields:
 
   - TCP / UDP / SCTP:


### PR DESCRIPTION
Hi Community ID Spec team!

I'm working on a project which will correlate host forensics data with network  (Bro and netflow) forensics data and am planning on using Community IDs to help me to easily pivot between the disparate data sources. This naturally made me wonder about directionality of flows: ala if swapping out source and destination IP/Ports would change the community ID hashes this standard specifies.

I was unable to determine based on the spec whether or not directionality mattered, so I did some testing with the [python implementation here](https://github.com/corelight/pycommunityid) and found that this statement is correct. 

I also may have misunderstood something, so feel free to close this pull request if appropriate. :)

Best Regards,
-Stefan