### PR TITLE
Add osquery to production implementations doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Production implementations
 - HELK: https://github.com/Cyb3rWard0g/HELK (with [Ruby implementation](https://github.com/Cyb3rWard0g/HELK/commit/e81a98a745a4d02acc9d346865aeb312b3ee599d#diff-81497c6343ac648c68637062cf1ba082))
 - MISP: https://www.misp-project.org/2019/07/19/MISP.2.4.111.released.html
 - Moloch (1.7.0+): https://github.com/aol/moloch/issues/966
+- Osquery (4.2.0+): https://osquery.readthedocs.io/en/latest/introduction/sql/#sql-additions
 - Suricata (4.1+): https://suricata.readthedocs.io/en/suricata-4.1.2/output/eve/eve-json-output.html#community-flow-id
 - VAST: https://github.com/vast-io/vast/pull/525
 - Zeek package (2.5+): https://github.com/corelight/bro-community-id


### PR DESCRIPTION
Osquery supports Community ID hashing as of 4.2.0.