### PR TITLE
Update README.md to include MISP-wireshark

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Production implementations
 - Elasticsearch (7.12.0+): https://www.elastic.co/guide/en/elasticsearch/reference/master/community-id-processor.html
 - HELK: https://github.com/Cyb3rWard0g/HELK (with [Ruby implementation](https://github.com/Cyb3rWard0g/HELK/commit/e81a98a745a4d02acc9d346865aeb312b3ee599d#diff-81497c6343ac648c68637062cf1ba082))
 - MISP: https://www.misp-project.org/2019/07/19/MISP.2.4.111.released.html
+- MISP-wireshark: https://github.com/MISP/misp-wireshark
 - Osquery (4.2.0+): https://osquery.readthedocs.io/en/latest/introduction/sql/#sql-additions, [blog post](https://dactiv.llc/blog/correlate-osquery-network-connections/)
 - Security Onion (2.0+): https://docs.securityonion.net/en/2.3/community-id.html
 - Suricata (4.1+): https://suricata.readthedocs.io/en/suricata-4.1.2/output/eve/eve-json-output.html#community-flow-id


### PR DESCRIPTION
Add misp-wireshark is a Lua plugin intended to help analysts extract data from Wireshark and convert it into the MISP Core format which includes community-id if available in Wireshark.